### PR TITLE
Allow for `MLEM.Formatting.Token` to have partial visibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vs
 bin
 obj
 packages

--- a/MLEM/Formatting/TokenizedString.cs
+++ b/MLEM/Formatting/TokenizedString.cs
@@ -117,6 +117,8 @@ namespace MLEM.Formatting {
                 var token = this.Tokens[t];
                 var drawFont = token.GetFont(font);
                 var drawColor = token.GetColor(color);
+                int literalIndex = 0;
+
                 for (var l = 0; l < token.SplitDisplayString.Length; l++) {
                     var line = token.SplitDisplayString[l];
                     for (var i = 0; i < line.Length; i++) {
@@ -125,13 +127,16 @@ namespace MLEM.Formatting {
                             token.DrawSelf(time, batch, pos + innerOffset, drawFont, color, scale, depth);
 
                         var cString = c.ToCachedString();
-                        token.DrawCharacter(time, batch, c, cString, i, pos + innerOffset, drawFont, drawColor, scale, depth);
+                        token.DrawCharacter(time, batch, c, cString, i, literalIndex, pos + innerOffset, drawFont, drawColor, scale, depth);
                         innerOffset.X += drawFont.MeasureString(cString).X * scale;
+
+                        literalIndex++;
                     }
                     // only split at a new line, not between tokens!
                     if (l < token.SplitDisplayString.Length - 1) {
                         innerOffset.X = token.InnerOffsets[l] * scale;
                         innerOffset.Y += font.LineHeight * scale;
+                        literalIndex++;
                     }
                 }
             }


### PR DESCRIPTION
I'm attempting to create a dialogue box system similar to that of any visual novel, where the text slowly appears within the text box character by character using `TokenizedString` and `Token`, however I've run into a few practical problems with the system:

- `TokenizedString` and `Token` both have internal constructor and are immutable.
- You can simply recreate the `TokenizedString` for every character revealed, however this seems costly and is also not compatible with animation codes like `<a wobble>` (as they are recreated every time, the animation is essentially frozen).

This PR proposes a solution to this by allowing `Token` to have a visible span, outside of which characters are not drawn.
Please let me know if this is something you'd want upstream, and if so what you'd want changing to merge in. If not I'm happy to keep this in my downstream branch.