### PR TITLE
Return a dummy scale if root is unset

### DIFF
--- a/MLEM.Ui/Elements/Element.cs
+++ b/MLEM.Ui/Elements/Element.cs
@@ -59,7 +59,7 @@ namespace MLEM.Ui.Elements {
         /// <summary>
         /// The scale that this ui element renders with
         /// </summary>
-        public float Scale => this.Root.ActualScale;
+        public float Scale => this.Root?.ActualScale ?? 0;
         /// <summary>
         /// The <see cref="Anchor"/> that this element uses for positioning within its parent
         /// </summary>


### PR DESCRIPTION
Closes #40
A quick fix of the `Element.Scale` failing when removing the elements mentioned in the issue.